### PR TITLE
javascript for dynamic select of network in the payment flow

### DIFF
--- a/pretix_eth/payment.py
+++ b/pretix_eth/payment.py
@@ -52,9 +52,11 @@ class TokenRatesJSONDecoder(JSONDecoder):
                 raise JSONDecodeError("Please supply integers or floats as values.", "aaabbb", 0)
         return decoded
 
+
 class EthereumPaymentForm(PaymentProviderForm):
     class Media:
         js = ('pretix_eth/eth_payment_form.js',)
+
 
 class Ethereum(BasePaymentProvider):
     identifier = "ethereum"
@@ -240,7 +242,6 @@ class Ethereum(BasePaymentProvider):
                     forms.ChoiceField(
                         label=_("Payment currency"),
                         help_text=_("Select the currency you will use for payment."),
-                        #widget=forms.RadioSelect,
                         choices=currency_type_choices,
                         initial="ETH",
                     ),


### PR DESCRIPTION
there is `pretix_eth/static/pretix_eth/eth_payment_form.js` javascript file that is enabled in the payment flow

it needs more frontend care:

* generate token list in the first Select dynamically based on the main Select (there might be more than just ETH and DAI)
* based on selected token (eg.: ETH or DAI) dynamically filter options in the main Select
* change the description in the main Select from "Choose Network and Token" to just "Choose Network" (in this code - via JS)
* style the two Select fields to sit next to each other: left and right