### PR TITLE
Run integration tests

### DIFF
--- a/.github/workflows/tox.yaml
+++ b/.github/workflows/tox.yaml
@@ -57,4 +57,5 @@ jobs:
       - name: ${{ matrix.toxenv }}
         run: tox
         env:
+          WEB3_PROVIDER_URI: ${{ secrets.WEB3_PROVIDER_URI }}
           TOXENV: ${{ matrix.toxenv }}

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ cmdclass = {
 extras_require = {
     'test': [
         'pytest>=5',
+        'pytest-django>=3.5',
         'celery>=5',
     ],
     'lint': [

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,6 @@ cmdclass = {
 extras_require = {
     'test': [
         'pytest>=5',
-        'pytest-django>=3.5',
         'celery>=5',
     ],
     'lint': [

--- a/tests/integration/test_confirm_payments.py
+++ b/tests/integration/test_confirm_payments.py
@@ -8,6 +8,7 @@ from django.test import RequestFactory
 
 
 WEB3_PROVIDER_URI = os.environ.get("WEB3_PROVIDER_URI")
+SINGLE_RECEIVER_ADDRESS = "0x0000000000000000000000000000000000000000"
 
 
 def check_web3_provider(pytesconfig):
@@ -66,12 +67,10 @@ TEST_ENOUGH_AMOUNT = [
     {
         "currency": "ETH - Goerli",
         "amount": int("1000", base=10),
-        "hex_address": "0xb84AC43014d60AE5dCe5d36975eE461f31e953d3",
     },  # Has about 0.5 ETH
     {
         "currency": "DAI - Goerli",
         "amount": int("1000", base=10),
-        "hex_address": "0x18FF3A11FAF05F83198A8724006975ce414872Bc",
     },  # Has about 48 DAI
 ]
 
@@ -84,10 +83,9 @@ def test_confirm_payment_enough(
     provider, event, get_request_order_payment, pytestconfig
 ):
     check_web3_provider(pytestconfig)
-    provider.settings.set("NETWORK_RPC_URL",
-                          {"Goerli_RPC_URL": WEB3_PROVIDER_URI})
-    provider.settings.set("SINGLE_RECEIVER_ADDRESS",
-                          "0x0000000000000000000000000000000000000000")
+    provider.settings.set("NETWORK_RPC_URL", {"Goerli_RPC_URL": WEB3_PROVIDER_URI})
+    provider.settings.set("SINGLE_RECEIVER_ADDRESS", SINGLE_RECEIVER_ADDRESS)
+
     payments = []
     orders = []
     for payment_info in TEST_ENOUGH_AMOUNT:
@@ -117,6 +115,7 @@ def test_confirm_payment_dry_run(
 ):
     check_web3_provider(pytestconfig)
     provider.settings.set("NETWORK_RPC_URL", {"Goerli_RPC_URL": WEB3_PROVIDER_URI})
+    provider.settings.set("SINGLE_RECEIVER_ADDRESS", SINGLE_RECEIVER_ADDRESS)
 
     payments = []
     orders = []
@@ -144,12 +143,10 @@ TEST_LOWER_AMOUNT = [
     {
         "currency": "ETH - Goerli",
         "amount": int("99000000", base=10),
-        "hex_address": "0xDb9574bf428A612fe13BEFFeB7F4bD8C73BF2D88",
     },  # Has about 10'000'000 wei
     {
         "currency": "DAI - Goerli",
         "amount": int("99000000", base=10),
-        "hex_address": "0x3d5091A1652e215c71C755BCfA97A08AFC9d6CB0",
     },  # Has about 32'035 wei
 ]
 
@@ -163,6 +160,7 @@ def test_confirm_payment_lower_amount(
 ):
     check_web3_provider(pytestconfig)
     provider.settings.set("NETWORK_RPC_URL", {"Goerli_RPC_URL": WEB3_PROVIDER_URI})
+    provider.settings.set("SINGLE_RECEIVER_ADDRESS", SINGLE_RECEIVER_ADDRESS)
 
     payments = []
     orders = []
@@ -188,12 +186,10 @@ TEST_WRONG_CURRENCY = [
     {
         "currency": "DAI - Goerli",
         "amount": int("1000", base=10),
-        "hex_address": "0xb84AC43014d60AE5dCe5d36975eE461f31e953d3",
     },  # Has enough amount, but in ETH
     {
         "currency": "ETH - Goerli",
         "amount": int("1000", base=10),
-        "hex_address": "0x18FF3A11FAF05F83198A8724006975ce414872Bc",
     },  # Has enough amount, but in DAI
 ]
 
@@ -207,6 +203,7 @@ def test_confirm_payment_wrong_currency(
 ):
     check_web3_provider(pytestconfig)
     provider.settings.set("NETWORK_RPC_URL", {"Goerli_RPC_URL": WEB3_PROVIDER_URI})
+    provider.settings.set("SINGLE_RECEIVER_ADDRESS", SINGLE_RECEIVER_ADDRESS)
 
     payments = []
     orders = []

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,6 @@ basepython=
     py37: python3.7
 passenv=
     WEB3_PROVIDER_URI
-    ETHERSCAN_API_KEY
 
 [testenv:lint]
 basepython=python3.8

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ exclude=venv,docs
 usedevelop=True
 commands=
     core: pytest {posargs:tests/core}
-    integration: pytest {posargs:tests/integration}
+    integration: pytest --require-web3 {posargs:tests/integration}
 extras=test
 basepython=
     py311: python3.11
@@ -22,6 +22,7 @@ basepython=
     py38: python3.8
     py37: python3.7
 passenv=
+    WEB3_PROVIDER_URI
     ETHERSCAN_API_KEY
 
 [testenv:lint]


### PR DESCRIPTION
### What was wrong?

integrations tests were skipped completely

### How was it fixed?

* the main happy path still does not work
* remove old pytest django's django_db_setup mock
* to run the test suite WEB3_PROVIDER_URI env var needs to be set
